### PR TITLE
Wrong user creation

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@ solr_user: solr
 solr_group: solr
 solr_user_uid: 810
 solr_group_gid: 810
+solr_user_shell: /bin/false
 
 # start on boot
 solr_service_enabled: true

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -21,7 +21,8 @@
   user:
     name: "{{ solr_user }}"
     group: "{{ solr_group }}"
-    home: /bin/false
+    home: "{{ solr_user_home }}"
+    shell: "{{ solr_user_shell }}"
     uid: "{{ solr_user_uid }}"
     createhome: true
     system: true

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -21,7 +21,7 @@
   user:
     name: "{{ solr_user }}"
     group: "{{ solr_group }}"
-    home: "{{ solr_user_home }}"
+    home: "{{ solr_home }}"
     shell: "{{ solr_user_shell }}"
     uid: "{{ solr_user_uid }}"
     createhome: true


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change
In debian based systems creating user solr with shell in /bin/false does not work. With this patch I propose to add a variable ``solr_user_shell`` to solve the issue, following the discussion in https://www.mail-archive.com/solr-user@lucene.apache.org/msg128029.html 

### Benefits

Admin can choose which shell assign to solr

### Possible Drawbacks

Security? But not according to documentation

### Applicable Issues

#68