### PR TITLE
Wrong user creation #68

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@ solr_user: solr
 solr_group: solr
 solr_user_uid: 810
 solr_group_gid: 810
+solr_user_shell: /bin/false
 
 # start on boot
 solr_service_enabled: true

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -21,7 +21,8 @@
   user:
     name: "{{ solr_user }}"
     group: "{{ solr_group }}"
-    home: /bin/false
+    home: "{{ solr_home }}"
+    shell: "{{ solr_user_shell }}"
     uid: "{{ solr_user_uid }}"
     createhome: true
     system: true


### PR DESCRIPTION
### Description of the Change

it seems that the script is using the shell as home for the creation of the solr user and this does not work on debian based systems. with this patch I propose to add a var ``solr_user_shell`` to define the shell (like suggested in https://www.mail-archive.com/solr-user@lucene.apache.org/msg128029.html) and to add the home argument in the install ansible to create the user solr with the defined ``solr_home`` variable.

### Benefits

The script will be even better

### Possible Drawbacks

None

### Applicable Issues

#68
